### PR TITLE
Fix callstack support, add callstack support to allocator

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -83,7 +83,7 @@ pub fn build(b: *std.Build) void {
     tracy_client.linkLibCpp();
     tracy_client.addCSourceFile(.{
         .file = tracy_src.path("./public/TracyClient.cpp"),
-        .flags = &.{},
+        .flags = &.{"-fno-sanitize=undefined"},
     });
     inline for (tracy_header_files) |header| {
         tracy_client.installHeader(


### PR DESCRIPTION
This commit does the following:

* Fixes callstack support by disabling the UB sanitizer in the Tracy build. This is taken from the Zig source and reflected in other issues like https://github.com/wolfpld/tracy/issues/602. Added as a C flag and not specifically through sanitize_c to ensure that we explicitly disable the UB sanitizer and nothing else.

* Adds callstack support to the allocator so that allocations can be stack traced.